### PR TITLE
[Feature][Antonio] Info drawer for application status updates log

### DIFF
--- a/app/(routes)/admin/manage-applications/_components/(column-header-controls)/(info-drawers)/application-status-info-drawer.tsx
+++ b/app/(routes)/admin/manage-applications/_components/(column-header-controls)/(info-drawers)/application-status-info-drawer.tsx
@@ -1,0 +1,109 @@
+import * as React from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+import useApplicationStatus from "@/hooks/use-application-status";
+
+interface DrawerDemoProps {
+  isDrawerOpen: boolean;
+  setIsDrawerOpen: (open: boolean) => void;
+  applicationId: string;
+}
+
+export function ApplicationStatusInfoDrawer({
+  isDrawerOpen,
+  setIsDrawerOpen,
+  applicationId,
+}: DrawerDemoProps) {
+  const { statusLogs, fetchStatusLogs } = useApplicationStatus();
+
+  React.useEffect(() => {
+    if (applicationId) {
+      fetchStatusLogs(applicationId);
+    }
+  }, [applicationId, fetchStatusLogs]);
+
+  // Sort statusLogs by applicationStatusLogId in descending order before rendering
+  const sortedStatusLogs = [...statusLogs].sort((a, b) => {
+    if (!a.applicationStatusLogId || !b.applicationStatusLogId) return 0;
+    return b.applicationStatusLogId.localeCompare(a.applicationStatusLogId);
+  });
+
+  return (
+    <Drawer open={isDrawerOpen} onOpenChange={setIsDrawerOpen}>
+      <DrawerContent>
+        <div className="mx-auto w-full max-w-sm">
+          <DrawerHeader>
+            <DrawerTitle>Application Status Log</DrawerTitle>
+            <DrawerDescription>{applicationId}</DrawerDescription>
+          </DrawerHeader>
+
+          {/* Status Logs Section */}
+          <div className="mt-4 h-64 overflow-y-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Date Edited</TableHead>
+                  <TableHead>Old Status</TableHead>
+                  <TableHead>New Status</TableHead>
+                  <TableHead>Editor</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {sortedStatusLogs.length > 0 ? (
+                  sortedStatusLogs.map((log) => (
+                    <TableRow
+                      key={log.applicationStatusLogId}
+                      className="text-xs"
+                    >
+                      <TableCell>
+                        {new Date(log.dateEdited).toLocaleString()}
+                      </TableCell>
+                      <TableCell>{log.oldApplicationStatus}</TableCell>
+                      <TableCell>{log.newApplicationStatus}</TableCell>
+                      <TableCell>
+                        {log.editorFirstname} {log.editorLastname}
+                      </TableCell>
+                    </TableRow>
+                  ))
+                ) : (
+                  <TableRow>
+                    <TableCell
+                      colSpan={4}
+                      className="text-center text-muted-foreground"
+                    >
+                      No status logs available
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
+
+          <DrawerFooter>
+            <DrawerClose asChild>
+              <Button variant="outline">Close</Button>
+            </DrawerClose>
+          </DrawerFooter>
+        </div>
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/app/(routes)/admin/manage-applications/_components/(column-header-controls)/application-status-cell.tsx
+++ b/app/(routes)/admin/manage-applications/_components/(column-header-controls)/application-status-cell.tsx
@@ -1,28 +1,32 @@
 import { useState } from "react";
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, Info } from "lucide-react";
 
+import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Button } from "@/components/ui/button";
 import useApplicationStatus from "@/hooks/use-application-status";
+import { ApplicationStatusInfoDrawer } from "./(info-drawers)/application-status-info-drawer";
 
 interface ApplicationStatusCellProps {
   applicationId: string;
+  isApplicationStatusEdited: boolean;
   currentApplicationStatus: string;
 }
 
 const ApplicationStatusCell: React.FC<ApplicationStatusCellProps> = ({
   applicationId,
+  isApplicationStatusEdited,
   currentApplicationStatus,
 }) => {
   const [selectedStatus, setSelectedStatus] = useState(
     currentApplicationStatus || "Unreviewed"
   );
   const { updateApplicationStatus, loading } = useApplicationStatus();
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false); // Drawer open state
 
   const statusOptions = [
     { value: "Transferred", bgColor: "bg-green-500" },
@@ -31,12 +35,10 @@ const ApplicationStatusCell: React.FC<ApplicationStatusCellProps> = ({
     { value: "Unreviewed", bgColor: "bg-gray-500" },
   ];
 
-  // Find the current selected status background color
   const currentStatus = statusOptions.find(
     (option) => option.value === selectedStatus
   );
 
-  // Handle status change and call the hook to update Firestore and log the change
   const handleStatusChange = async (newApplicationStatus: string) => {
     setSelectedStatus(newApplicationStatus);
     await updateApplicationStatus(
@@ -47,35 +49,63 @@ const ApplicationStatusCell: React.FC<ApplicationStatusCellProps> = ({
   };
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          className={`flex w-full items-center px-4 py-2 rounded text-white transition-colors ${
-            loading
-              ? "bg-muted-foreground"
-              : currentStatus?.bgColor || "bg-gray-500"
-          }`}
-          disabled={loading}
-        >
-          {loading ? "Updating..." : selectedStatus}
-          <ChevronDown className="ml-2 w-4 h-4" />
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent>
-        {statusOptions.map((option) => (
-          <DropdownMenuItem key={option.value} asChild>
-            <div
-              className={`px-4 py-2 cursor-pointer text-sm ${
-                selectedStatus === option.value ? "font-bold" : "font-normal"
-              } `}
-              onClick={() => handleStatusChange(option.value)}
-            >
-              {option.value}
+    <>
+      <div className="relative w-full flex justify-between items-center">
+        {/* Dropdown Menu Button */}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <div className="flex-1">
+              <Button
+                className={`flex w-full items-center px-4 py-2 rounded text-white transition-colors ${
+                  loading
+                    ? "bg-muted-foreground"
+                    : currentStatus?.bgColor || "bg-gray-500"
+                }`}
+                disabled={loading}
+              >
+                {loading ? "Updating..." : selectedStatus}
+                <ChevronDown className="ml-2 w-4 h-4" />
+              </Button>
             </div>
-          </DropdownMenuItem>
-        ))}
-      </DropdownMenuContent>
-    </DropdownMenu>
+          </DropdownMenuTrigger>
+
+          <DropdownMenuContent>
+            {statusOptions.map((option) => (
+              <DropdownMenuItem key={option.value} asChild>
+                <div
+                  className={`px-4 py-2 cursor-pointer text-sm ${
+                    selectedStatus === option.value
+                      ? "font-bold"
+                      : "font-normal"
+                  } `}
+                  onClick={() => handleStatusChange(option.value)}
+                >
+                  {option.value}
+                </div>
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        {/* Info Icon positioned in the lower right of the button */}
+        {/* Rendered when the application status is edited */}
+        {isApplicationStatusEdited && (
+          <div
+            className="absolute right-0 bottom-0 p-1 cursor-pointer"
+            onClick={() => setIsDrawerOpen(true)}
+          >
+            <Info className="w-4 h-4 text-secondary-foreground hover:text-secondary" />
+          </div>
+        )}
+      </div>
+
+      {/* Pass isDrawerOpen to DrawerDemo and control its visibility */}
+      <ApplicationStatusInfoDrawer
+        isDrawerOpen={isDrawerOpen}
+        setIsDrawerOpen={setIsDrawerOpen}
+        applicationId={applicationId}
+      />
+    </>
   );
 };
 

--- a/app/(routes)/admin/manage-applications/_components/columns.tsx
+++ b/app/(routes)/admin/manage-applications/_components/columns.tsx
@@ -44,6 +44,9 @@ export const columns: ColumnDef<ApplicantData>[] = [
     cell: ({ row, cell }) => (
       <ApplicationStatusCell
         applicationId={row.original.applicationId as string}
+        isApplicationStatusEdited={
+          row.original.isApplicationStatusEdited as boolean
+        }
         currentApplicationStatus={(cell.getValue() as string) || "Unreviewed"}
       />
     ),

--- a/components/ui/drawer.tsx
+++ b/components/ui/drawer.tsx
@@ -1,0 +1,118 @@
+"use client"
+
+import * as React from "react"
+import { Drawer as DrawerPrimitive } from "vaul"
+
+import { cn } from "@/lib/utils"
+
+const Drawer = ({
+  shouldScaleBackground = true,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) => (
+  <DrawerPrimitive.Root
+    shouldScaleBackground={shouldScaleBackground}
+    {...props}
+  />
+)
+Drawer.displayName = "Drawer"
+
+const DrawerTrigger = DrawerPrimitive.Trigger
+
+const DrawerPortal = DrawerPrimitive.Portal
+
+const DrawerClose = DrawerPrimitive.Close
+
+const DrawerOverlay = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Overlay
+    ref={ref}
+    className={cn("fixed inset-0 z-50 bg-black/80", className)}
+    {...props}
+  />
+))
+DrawerOverlay.displayName = DrawerPrimitive.Overlay.displayName
+
+const DrawerContent = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DrawerPortal>
+    <DrawerOverlay />
+    <DrawerPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-background",
+        className
+      )}
+      {...props}
+    >
+      <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-muted" />
+      {children}
+    </DrawerPrimitive.Content>
+  </DrawerPortal>
+))
+DrawerContent.displayName = "DrawerContent"
+
+const DrawerHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("grid gap-1.5 p-4 text-center sm:text-left", className)}
+    {...props}
+  />
+)
+DrawerHeader.displayName = "DrawerHeader"
+
+const DrawerFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+    {...props}
+  />
+)
+DrawerFooter.displayName = "DrawerFooter"
+
+const DrawerTitle = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+DrawerTitle.displayName = DrawerPrimitive.Title.displayName
+
+const DrawerDescription = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+DrawerDescription.displayName = DrawerPrimitive.Description.displayName
+
+export {
+  Drawer,
+  DrawerPortal,
+  DrawerOverlay,
+  DrawerTrigger,
+  DrawerClose,
+  DrawerContent,
+  DrawerHeader,
+  DrawerFooter,
+  DrawerTitle,
+  DrawerDescription,
+}

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -1,0 +1,15 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("animate-pulse rounded-md bg-muted", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "sonner": "^1.5.0",
         "tailwind-merge": "^2.5.2",
         "tailwindcss-animate": "^1.0.7",
+        "vaul": "^0.9.4",
         "zustand": "^4.5.5"
       },
       "devDependencies": {
@@ -7114,6 +7115,19 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/vaul": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/vaul/-/vaul-0.9.4.tgz",
+      "integrity": "sha512-pcyIy1nEk6798ReNQpbVH/T/dYnoJ3bwyq7jmSp134s+bSvpWoSWQthm3/jfsQRvHNYIEK4ZKbkHUJ3YfLfw1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-dialog": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
     },
     "node_modules/websocket-driver": {
       "version": "0.7.4",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
+    "vaul": "^0.9.4",
     "zustand": "^4.5.5"
   },
   "devDependencies": {


### PR DESCRIPTION
- Added drawer and skeleton component from shadcn/ui
- Modified `applicationStatusLogId` format to `"000000001 MM-DD-YY, HH:MM:SS AM/PM"` for simpler database lookup and easier date sorting
- Added an Info icon on the lower right of the application status button that only renders when the `isApplicationStatusEdited` flag is true
- Added `application-status-info-drawer.tsx` component
	- Opened when the Info icon is clicked
	- Only displays the log of the updates of that particular `applicationId` holder row